### PR TITLE
Made a PlatformIO project out of the repo + tested w/ Arduino Uno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The software associated with the CPSS FAR 10K rocket competition project titled 
 
 This project uses PlatformIO
 
-# Design rules:
+# Design Rules:
 ## Comments:
 -   Write understandable comments. they don't need to be pretty. Write the comments you would want to read if you had never seen your code before.  
 -   Comments are strongly reccomended for these areas:
@@ -14,7 +14,7 @@ This project uses PlatformIO
   -   Library Calls. Explain what the library function is doing if its not clear. No one wants dig through docs.
 
 # Working as a Team:
-## helpful terms for those new to git:
+## Helpful Terms for Those New to Git:
 - git: 
   Git is the protocol and the set of tools used for version control and code colaboration
 - repository: 
@@ -39,6 +39,8 @@ This project uses PlatformIO
 - Develop the feature on a branch and commit the work
 - Fetch and merge from the remote again (in case new commits were made, make sure your feature still works with the current production)
 - Push branch up to the remote
+
+# Resources
 
 ## Helpful Links:
 - Codecademy page on git collaboration: https://www.codecademy.com/learn/learn-git/modules/learn-git-git-teamwork-u/cheatsheet

--- a/include/README
+++ b/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/lib/README
+++ b/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,14 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino

--- a/src/main.ino
+++ b/src/main.ino
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+
+void setup() 
+{
+
+}
+
+
+void loop()
+{
+
+}

--- a/test/README
+++ b/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
...in case we wanted to use PlatformIO. It does all of the setup for boards and libraries for us and makes moving the same code between the two platforms a much smoother transition (for when we develop on Arduino boards and then move the code to Teensies or such). 

All of the plugins available in the Arduino IDE are available through the PlatformIO home page, along with a list of the boards they're compatible with (which can show us which libraries work with Teensy boards). We can also filter by libraries that work with Teensies.